### PR TITLE
Add bindEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ var MyView = View.extend({
     // define a context for the template
   }
 
+, bindEvents: function () {
+    // gets called before loadData is called in render
+    // useful for listening to model
+  }
+
 , beforeRender: function () {
     // gets called before it's rendered
   }

--- a/extend.js
+++ b/extend.js
@@ -56,6 +56,10 @@ Ribcage = {
     var self = this
       , model = this.model;
 
+    if(typeof this.bindEvents == 'function') {
+      this.bindEvents()
+    }
+
     if (!this._dataLoaded) {
       return this.loadData(function () {
         self._dataLoaded = true


### PR DESCRIPTION
This calls `bindEvents` before `loadData` on every render. It makes dealing with `Backbone.sync` much cleaner.

Use case:

``` js
myView = Ribcage.extend({
  afterInit: function () {
    this.model = new MyModel()
  }
, bindEvents: function () {
    this.listenTo(this.model, 'change', this.render, this);
  }
, loadData: function (cb) {
    this.model.once('sync', cb);
    this.model.fetch();
  }
});
```

Notes:
- I didn't call it `beforeLoadData` because it has to run on every render, not just renders that load data.
- I couldn't bind my events in `afterRender` because it doesn't get called if data isn't loaded yet. So the model would sync, but the event wouldn't be bound and the view wouldn't update
- This is really useful in subviews because if the parent view is rendered the events don't disappear
