### PR TITLE
Switch to jquery module, don't clobber Backbone.$ if a global jquery exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Backbone = require('backbone')
-  , $ = require('jquery-browserify')
+    // Use the global jQuery if possible -- it might have plugins on it
+  , $ = window.$ ? window.$ : require('jquery')(window)
   , extend = require('./extend')
   , Base;
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "dependencies": {
     "backbone": "~1.0.0",
     "lodash": "~1.2.1",
-    "jquery-browserify": "~1.8.1"
+    "jquery": "~2.1.0-beta3"
   }
 }


### PR DESCRIPTION
Been using the new jquery module for a while now, it seems stable.

This change looks for a global jquery before requiring a fresh copy for Backbone.

Blowing over an existing jQuery in Backbone is bad because it has an event/selector cache and possible plugins attached to it.
