### PR TITLE
Add a `this.parent` key for subviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ var ViewWithSubviews = View.extend({
     this.closeSubviews();
 
   }
+  , afterInit: function(){
+    // this.parent is a reference to the subview's parent view.
+    this.listenTo(this.parent.collection, 'change', this.render)
+  }
 
 });
 

--- a/extend.js
+++ b/extend.js
@@ -113,7 +113,7 @@ Ribcage = {
     _.each(this.subviews, iterator);
   }
 
-, _attachSubView: function(view){
+, _attachSubview: function(view){
     this.subviews = this.subviews || {};
     this.subviewByModelId = this.subviewByModelId || {};
 
@@ -123,13 +123,16 @@ Ribcage = {
       this.subviewByModelId[view.model.id].push(view);
     }
 
+    // let the subview store a reference to its parent
+    view.parent || (view.parent = this)
+
     return view;
   }
 
 , appendSubview: function(view, el) {
     el || (el = this.$el);
 
-    this._attachSubView(view);
+    this._attachSubview(view);
 
     el.append(view.el);
 
@@ -146,7 +149,7 @@ Ribcage = {
 , prependSubview: function(view, el) {
     el || (el = this.$el);
 
-    this._attachSubView(view);
+    this._attachSubview(view);
 
     el.prepend(view.el);
 

--- a/test/entry.js
+++ b/test/entry.js
@@ -5,6 +5,7 @@ var assert = require('assert')
   , fixture = document.getElementById('fixture')
   , CollectionView = require('./fixtures/CollectionView')
   , ButtonHolderView = require('./fixtures/ButtonHolderView')
+  , _ = require('lodash')
   , instances = {}; // A temporary holder that we can `delete` to clear leaks
 
 mocha.setup({
@@ -71,6 +72,13 @@ describe('Extended Views', function () {
 
     it('should have 100 children', function () {
       assert.equal(fixture.childNodes[0].childNodes.length, 100);
+    });
+
+    it('should have a reference to its parent view', function(){
+      var subview = _.find(instances.collectionInstance.subviews, function(subview){
+          return subview.cid;
+        });
+      assert.equal( subview.parent.cid,  instances.collectionInstance.cid);
     });
 
     it('should detach when closed', function () {


### PR DESCRIPTION
Allows subviews to easily reference their parent view.
