### PR TITLE
Close refactor

### DIFF
--- a/extend.js
+++ b/extend.js
@@ -226,6 +226,8 @@ Ribcage = {
     }
 
     this.closeSubviews(options);
+    this.undelegateEvents();
+    this.stopListening();
     if (!options.keepDom) this.remove();
   }
 


### PR DESCRIPTION
breaking change! Subviews are now no longer removed when closing the parent view. We assume that children DOM elements will be removed when their parent is removed.
